### PR TITLE
Allow line height of 1

### DIFF
--- a/petrock.asm
+++ b/petrock.asm
@@ -43,7 +43,7 @@ ScratchStart:
     VU:              .res  1            ; VU Audio Data
     Peaks:           .res  NUM_BANDS    ; Peak Data for current frame
     NextStyle:       .res  1            ; The next style we will pick
-    CharDefs:        .res  8            ; Storage for the visualDef currently in use
+    CharDefs:        .res  10           ; Storage for the visualDef currently in use
     SerialBufLen = 12                   ; Matches the packet size from ESP32
     SerialBufPos:    .res  1            ; Current index into serial buffer
     SerialBuf:       .res  SerialBufLen ; Serial buffer for: "DP" + 1 byte vu + 8 PeakBytes
@@ -963,10 +963,7 @@ FcColorMem:     lda #YSIZE-TOP_MARGIN-BOTTOM_MARGIN   ; Count of rows to paint c
 ;
 ; the bar top, the bar middle, or bar bottom
 
-DrawBand:       cmp #1                ; Can't draw height 1
-                bne :+
-                rts
-:               sta Height            ; Height is height of bar itself
+DrawBand:       sta Height            ; Height is height of bar itself
                 txa
                 asl
                 sta SquareX           ; Bar xPos on screen
@@ -995,8 +992,10 @@ lineSwitch:     ldy SquareX           ; Y will be the X-pos (zp addr mode not su
                 cmp #YSIZE - BOTTOM_MARGIN - 1
                 bne @notlastline
                 lda Height            ; If 0 height, write blanks instead of band base
-                bne drawLastLine
                 beq drawLastBlanks
+                cmp #1
+                beq drawOneLine
+                bne drawLastLine
 @notlastline:   cmp SquareY           ; Compare to screen line of top of bar
                 bcc drawBlanks
                 beq drawFirstLine
@@ -1031,6 +1030,14 @@ drawLastLine:
                 sta (zptmp),y         ; line to the Y register.
                 iny
                 lda CharDefs + visualDef::BOTTOMRIGHTSYMBOL
+                sta (zptmp),y
+                rts
+drawOneLine:
+                ldy SquareX
+                lda CharDefs + visualDef::ONELINE1SYMBOL
+                sta (zptmp),y
+                iny
+                lda CharDefs + visualDef::ONELINE2SYMBOL
                 sta (zptmp),y
                 rts
 drawLastBlanks:
@@ -1117,16 +1124,16 @@ SetNextStyle:   lda NextStyle         ; Take the style index and multiply by 2
 ; and horizontal and vertical lines needed to form a box.
 
 SkinnyRoundStyle:                     ; PETSCII screen codes for round tube bar style
-  .byte 85, 73, 74, 75, 66, 66, 74, 75
+  .byte 85, 73, 74, 75, 66, 66, 74, 75, 32, 32
 
 DrawSquareStyle:                      ; PETSCII screen codes for square linedraw style
-  .byte 79, 80, 76, 122, 101, 103, 76, 122
+  .byte 79, 80, 76, 122, 101, 103, 76, 122, 32, 32
 
 BreakoutStyle:                        ; PETSCII screen codes for style that looks like breakout
-  .byte 239, 250, 239, 250, 239, 250, 239, 250
+  .byte 239, 250, 239, 250, 239, 250, 239, 250, 239, 250
 
 CheckerboardStyle:                    ; PETSCII screen codes for checkerboard style
-  .byte 102, 92, 102, 92, 102, 92,102, 92
+  .byte 102, 92, 102, 92, 102, 92,102, 92, 102, 92
 
 ; Lookup table - each of the above mini tables is listed in this lookup table so that
 ;                we can easily find items 0-3

--- a/petrock.inc
+++ b/petrock.inc
@@ -33,7 +33,7 @@ COLOR_MEM           = $d800   ; Screen color memory of 1000 bytes
 
 ; Serial magic bytes
 
-MAGIC_LEN = 8                   ; Size of full packet
+MAGIC_LEN           = 8         ; Size of full packet
 MAGIC_BYTE_0        = 68        ; ASCII 'D'       
 MAGIC_BYTE_1        = 80        ; ASCII 'P'
 
@@ -125,6 +125,8 @@ VUSYMBOL            = 244               ; Symbol for a filled VU square
   VLINE2SYMBOL      .byte
   HLINE1SYMBOL      .byte
   HLINE2SYMBOL      .byte
+  ONELINE1SYMBOL    .byte
+  ONELINE2SYMBOL    .byte
 .endstruct
 
 ; Our UI Definitions ------------------------------------------------------


### PR DESCRIPTION
This adds support for bands of height 1 for visual styles that allow ir. Behavior is now as follows:
- Height 0: band is cleared
- Height 1: band of height 1 is drawn, in accordance with band style's specific "1 row band chars", that I've added to visualDef
- Height >1: band is drawn as before