### PR TITLE
Put serial ressponse asterisk back

### DIFF
--- a/petrock.asm
+++ b/petrock.asm
@@ -272,7 +272,7 @@ drawAllBands:   ldx #NUM_BANDS - 1    ; Draw each of the bands in reverse order
 
                 jsr CheckTextTimer
 
-.if C64         ; Color's only relevant on the C64
+.if C64         
                 lda #'*'              ; Send a * back to the host
                 jsr PutSerialChar
 .endif

--- a/petrock.asm
+++ b/petrock.asm
@@ -272,9 +272,10 @@ drawAllBands:   ldx #NUM_BANDS - 1    ; Draw each of the bands in reverse order
 
                 jsr CheckTextTimer
 
+.if C64         ; Color's only relevant on the C64
                 lda #'*'              ; Send a * back to the host
                 jsr PutSerialChar
-
+.endif
                 jsr GETIN             ; Keyboard Handling - check for RUN
 
                 cmp #0

--- a/petrock.asm
+++ b/petrock.asm
@@ -272,8 +272,8 @@ drawAllBands:   ldx #NUM_BANDS - 1    ; Draw each of the bands in reverse order
 
                 jsr CheckTextTimer
 
-                ; lda #'*'              ; Send a * back to the host
-                ; jsr PutSerialChar
+                lda #'*'              ; Send a * back to the host
+                jsr PutSerialChar
 
                 jsr GETIN             ; Keyboard Handling - check for RUN
 


### PR DESCRIPTION
Restores the sending of the * character as packets are processed so that the ESP32 gets the ACK and can count processed frames per second.