### PR TITLE
Correct PET keyboard poll routine

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: "Build cc65"
       run: |

--- a/serial/pet/driver.s
+++ b/serial/pet/driver.s
@@ -564,7 +564,7 @@ IrqHandler:     ; 36 cycles till we hit here from IRQ firing
                 dec KbdPollCnt
                 beq @finish           ; 0, so finish polling
                 lda KbdPollCnt
-                cmp #$11
+                cmp #11
                 beq @setup            ; 11, so setup polling
                 bcs @exit             ; > 11, so we're still counting down
                 ; One of the 10 scanning rows ;1-10


### PR DESCRIPTION
The fast keyboard poll routine in the PET serial driver incorrectly started the actual keyboard polling when the countdown reached $11 (17), instead of 11. Although this works, it wastes time polling the keyboard for non-existent rows, that being those beyond the decimal 10 that do exist.